### PR TITLE
fix: brings Identicon to parity with Mist

### DIFF
--- a/src/components/Identicon.jsx
+++ b/src/components/Identicon.jsx
@@ -1,41 +1,35 @@
 /* eslint-disable */
 import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import blockies from 'ethereum-blockies'
-// import i18n from '../i18n'
+import styled from 'styled-components'
 import hqxConstructor from '../lib/hqx'
 
-// window.blockies = blockies
-
 const mod = {
-  Math: window.Math,
+  Math: window.Math
 }
 hqxConstructor(mod)
 const { hqx } = mod
 
-// copied from https://github.com/ethereum/meteor-package-elements/blob/master/identicon.html
-// see also https://github.com/ethereum/blockies/blob/master/react-component.js
-// see also https://github.com/alexvandesande/meteor-identicon/blob/master/lib/identicon.js
-export default class DappIdenticon extends Component {
-  constructor(props) {
-    super(props)
-    let seed = this.props.seed || '0x0000000000000000000000000000000000000000'
-    const identity = seed.toLowerCase()
-    this.state = {
-      imageData: this.identiconData(identity), // cache image data
-    }
+export default class Identicon extends Component {
+  static propTypes = {
+    seed: PropTypes.string,
+    size: PropTypes.oneOf(['tiny', 'small', 'medium', 'large'])
   }
 
   // uses hqx pixel scaling with max value 4 x 2 = factor 8
   identiconData(identity) {
-    return hqx(hqx(
-      blockies.create({
-        seed: identity,
-        size: 8,
-        scale: 1,
-      }),
-      4,
-    ), 4)
-      .toDataURL()
+    return hqx(
+      hqx(
+        blockies.create({
+          seed: identity,
+          size: 8,
+          scale: 1
+        }),
+        4
+      ),
+      4
+    ).toDataURL()
   }
 
   // uses blockie's factor 8 scaling
@@ -44,28 +38,78 @@ export default class DappIdenticon extends Component {
       .create({
         seed: identity,
         size: 8,
-        scale: 8,
+        scale: 8
       })
       .toDataURL()
   }
 
-  renderJazzIdenticon(address) {
-    // if we wrap jazzicon here we should probably lazy-load it
-    // https://github.com/MetaMask/metamask-extension/blob/60feeb393be5d84679dd7b94dba58540ffa166bd/ui/lib/icon-factory.js
-    return (
-      <span>placeholder</span>
-    )
-  }
-
   render() {
-    if (this.props.jazz) {
-      return this.renderJazzIdenticon(this.props.seed)
-    }
+    const {
+      seed = '0x0000000000000000000000000000000000000000',
+      size = 'medium'
+    } = this.props
 
     return (
-      <span title="elements.identiconHelper">
-        <img src={this.state.imageData} width="64" height="64" className="identicon-pixel" />
-      </span>
+      <StyledSpan
+        backgroundImage={`url('${this.identiconData(seed.toLowerCase())}')`}
+        size={size}>
+        <StyledImg
+          src={this.identiconDataPixel(seed.toLowerCase())}
+          className="identicon-pixel"
+        />
+      </StyledSpan>
     )
   }
 }
+
+const config = {
+  tiny: {
+    width: '21px',
+    boxShadow:
+      'inset 0 1px 1px hsla(0,0%,100%,.4), inset 0 -1px 2px rgba(0,0,0,.3)'
+  },
+  small: {
+    width: '32px',
+    boxShadow:
+      'inset 0 2px 2px hsla(0,0%,100%,.4), inset 0 -2px 4px rgba(0,0,0,.4)'
+  },
+  medium: {
+    width: '48px',
+    boxShadow:
+      'inset 0 4px 4px hsla(0,0%,100%,.4), inset 0 -4px 6px rgba(0,0,0,.5)'
+  },
+  large: {
+    width: '64px',
+    boxShadow:
+      'inset 0 4px 8px hsla(0,0%,100%,.4), inset 0 -4px 12px rgba(0,0,0,.6)'
+  }
+}
+
+const StyledSpan = styled.span`
+  background-image: ${props => props.backgroundImage};
+  background-size: cover;
+  border-radius: 50%;
+  box-shadow: ${props => config[props.size].boxShadow};
+  cursor: help;
+  display: inline-block;
+  overflow: hidden;
+  transition: border-radius 2.5s;
+  transition-delay: 3s;
+  height: ${props => config[props.size].width};
+  width: ${props => config[props.size].width};
+  :hover {
+    border-radius: 15%;
+    transition-delay: 1s;
+  }
+`
+
+const StyledImg = styled.img`
+  height: 100%;
+  width: 100%;
+  transition: opacity 5s;
+  opacity: 0;
+  :hover {
+    transition: opacity 0.25s;
+    opacity: 1;
+  }
+`

--- a/src/stories/1.index.stories.jsx
+++ b/src/stories/1.index.stories.jsx
@@ -22,18 +22,22 @@ storiesOf('Welcome', module).add('to Ethereum Components', () => (
 ))
 
 storiesOf('Widgets/Identicon', module)
-  .add('with seed', () => (
-    <Identicon seed="0xF5A5d5c30BfAC14bf207b6396861aA471F9A711D" />
+  .add('default', () => <Identicon />)
+  .add('tiny (with seed)', () => (
+    <Identicon seed="0xF5A5d5c30BfAC14bf207b6396861aA471F9A711D" size="tiny" />
   ))
-  .add(
-    'with radius',
-    () => <Identicon seed="0xF5A5d5c30BfAC14bf207b6396861aA471F9A711D" />,
-    {
-      notes: {
-        markdown: '# Title '
-      }
-    }
-  )
+  .add('small (with seed)', () => (
+    <Identicon seed="0xF5A5d5c30BfAC14bf207b6396861aA471F9A711D" size="small" />
+  ))
+  .add('medium (with seed)', () => (
+    <Identicon
+      seed="0xF5A5d5c30BfAC14bf207b6396861aA471F9A711D"
+      size="medium"
+    />
+  ))
+  .add('large (with seed)', () => (
+    <Identicon seed="0xF5A5d5c30BfAC14bf207b6396861aA471F9A711D" size="large" />
+  ))
 
 storiesOf('Widgets/Animations/Spinner', module).add('default', () => (
   <Spinner />


### PR DESCRIPTION
#### What does it do?
- styles via SC
- handles cases: tiny, small, medium, large (as seen in Mist)
- strips out optimizations for now (e.g. caching, jazzicons)
- closes #1 