### PR TITLE
fix: updates EthAddress with wallet feedback

### DIFF
--- a/src/components/EthAddress.jsx
+++ b/src/components/EthAddress.jsx
@@ -1,47 +1,27 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import Identicon from './Identicon';
+import React from 'react'
+import PropTypes from 'prop-types'
 
-const EthAddress = ({
-  address, short, identicon, onClick,
-}) => (
+const EthAddress = ({ address, short = false, onClick }) => (
   <span className="eth-address" onClick={onClick}>
-    {identicon === true && <Identicon seed={address} />}
     {short
-      ? [...address.split('').slice(0, 10), '...', ...address.split('').slice(42 - 10)].join('')
-      : address
-    }
-
-    {/* language=CSS */}
-    <style jsx>
-      {`
-      .eth-address {
-        color: black;
-        padding: 4px 10px;
-        font-size: 14px;
-        border: 1px solid gray;
-        border-radius: 4px;
-        cursor: pointer;
-      }
-    `}
-    </style>
+      ? [
+          ...address.split('').slice(0, 10),
+          '...',
+          ...address.split('').slice(42 - 10)
+        ].join('')
+      : address}
   </span>
-);
+)
 
-EthAddress.displayName = 'EthAddress';
+EthAddress.displayName = 'EthAddress'
 
 EthAddress.propTypes = {
   /** Ethereum public address (42 chars)  */
   address: PropTypes.string.isRequired,
-  /** Display abbreviated form with '...'& 23 instead of 42 chars.  */
+  /** Display abbreviated form with '...' (23 chars)  */
   short: PropTypes.bool,
-  /** Displays the identicon next to the address */
-  identicon: PropTypes.bool,
-};
+  /** Callback to be executed onClick */
+  onClick: PropTypes.func
+}
 
-EthAddress.defaultProps = {
-  short: false,
-  identicon: false,
-};
-
-export default EthAddress;
+export default EthAddress

--- a/src/stories/1.index.stories.jsx
+++ b/src/stories/1.index.stories.jsx
@@ -77,13 +77,12 @@ storiesOf('Widgets/Eth Address', module)
   .add('shortened', () => (
     <EthAddress short address="0xF5A5d5c30BfAC14bf207b6396861aA471F9A711D" />
   ))
-  .add('with identicon', () => (
+  .add('with callback', () => (
     <EthAddress
-      identicon
+      onClick={() => alert('clicked!')}
       address="0xF5A5d5c30BfAC14bf207b6396861aA471F9A711D"
     />
   ))
-  .add('click -> copy to clipboard', () => <span>placeholder</span>)
 
 storiesOf('Widgets/Eth QR', module)
   .add('default', () => (


### PR DESCRIPTION
#### What does it do?
- Simplifies EthAddress to props: address, short, onClick
- Closes #22 
#### Background
Jumped on a screenshare with @kielbarry to talk through usage within the wallet. We agreed that the first iteration shouldn't couple styling or identicons. Will continue to evaluate once pulled into the repo.