### PR TITLE
praha: some sanity checks, title tooltip, added passable classes et al

### DIFF
--- a/src/components/Identicon.jsx
+++ b/src/components/Identicon.jsx
@@ -44,17 +44,28 @@ export default class Identicon extends Component {
   }
 
   render() {
-    const {
-      seed = '0x0000000000000000000000000000000000000000',
-      size = 'medium'
-    } = this.props
+
+    const seed = this.props.seed ? this.props.seed : '0x0000000000000000000000000000000000000000'
+    const size = this.props.size ? this.props.size : 'medium'
+    const image = this.identiconData(seed.toLowerCase())
+    const classes = this.props.classes ? this.props.classes : ''
+
+    seed === '0x0000000000000000000000000000000000000000'
+      ? console.warn("A seed was not passed as a prop to the Identicon")
+      : null
 
     return (
       <StyledSpan
-        backgroundImage={`url('${this.identiconData(seed.toLowerCase())}')`}
-        size={size}>
+        className={classes}
+        backgroundImage={`url('${image}')`}
+        size={size}
+        title={this.props.title 
+          ? `This is a security icon. If there were any change to the address, the resulting icon would be a completely different one`
+          : null
+        }
+        >
         <StyledImg
-          src={this.identiconDataPixel(seed.toLowerCase())}
+          src={image}
           className="identicon-pixel"
         />
       </StyledSpan>

--- a/src/components/Identicon.jsx
+++ b/src/components/Identicon.jsx
@@ -47,7 +47,6 @@ export default class Identicon extends Component {
 
     const seed = this.props.seed ? this.props.seed : '0x0000000000000000000000000000000000000000'
     const size = this.props.size ? this.props.size : 'medium'
-    const image = this.identiconData(seed.toLowerCase())
     const classes = this.props.classes ? this.props.classes : ''
 
     seed === '0x0000000000000000000000000000000000000000'
@@ -57,7 +56,7 @@ export default class Identicon extends Component {
     return (
       <StyledSpan
         className={classes}
-        backgroundImage={`url('${image}')`}
+        backgroundImage={`url('${this.identiconData(seed.toLowerCase())}')`}
         size={size}
         title={this.props.title 
           ? `This is a security icon. If there were any change to the address, the resulting icon would be a completely different one`
@@ -65,7 +64,7 @@ export default class Identicon extends Component {
         }
         >
         <StyledImg
-          src={image}
+          src={this.identiconDataPixel(seed.toLowerCase())}
           className="identicon-pixel"
         />
       </StyledSpan>


### PR DESCRIPTION
This PR adds some error handling that can occur in my app, adds a tooltip that exists in the browser wallet, and calls identiconData function once.

Note: The classes implementation I have added is not the best solution, as I believe the classes props are applied before the styles of the StyledSpan.