### PR TITLE
praha: sanitycheck for missing props and adding custom classes

### DIFF
--- a/src/components/EthAddress.jsx
+++ b/src/components/EthAddress.jsx
@@ -1,17 +1,24 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-const EthAddress = ({ address, short = false, onClick }) => (
-  <span className="eth-address" onClick={onClick}>
-    {short
-      ? [
-          ...address.split('').slice(0, 10),
-          '...',
-          ...address.split('').slice(42 - 10)
-        ].join('')
-      : address}
-  </span>
-)
+const EthAddress = ({ address, short = false, onClick, classes }) => {
+
+ !address
+   ? short = false
+   : null
+
+  return (
+    <span className={"eth-address " + classes} onClick={onClick}>
+      {short
+        ? [
+            ...address.split('').slice(0, 10),
+            '...',
+            ...address.split('').slice(42 - 10)
+          ].join('')
+        : address}
+    </span>
+  )
+}
 
 EthAddress.displayName = 'EthAddress'
 


### PR DESCRIPTION
This PR adds a classes props that allows for so implementors can add custom class names, and adds a sanity check for address prop inputs.

For example, in my app, a contract pending deployment uses the contract address field which remains undefined until deployment is confirmed. Short = false prevents .split() from being performed on 'undefined' props.