### PR TITLE
fix: clean up identicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![CircleCI](https://circleci.com/gh/PhilippLgh/ethereum-react-components.svg?style=shield)](https://circleci.com/gh/PhilippLgh/ethereum-react-components)
 
 # Ethereum React Components
+
 A library of frequently used Ethereum React components to display and handle addresses, transactions, accounts...
 
 For a detailed documentation of all available components check out [the generated storybook](https://philipplgh.github.io/ethereum-react-components)
@@ -8,14 +9,16 @@ For a detailed documentation of all available components check out [the generate
 WARNING: this lib is not production ready
 
 # Examples
-Two projects using these components are 
+
+Two projects using these components are
+
 - [Mist React](https://github.com/ethereum/mist-ui-react)
 - [Mist](https://github.com/ethereum/mist)
-
 
 # Development
 
 ## Clone & Storybook
+
 ```
 git clone https://github.com/PhilippLgh/ethereum-react-components.git
 cd ethereum-react-components
@@ -24,6 +27,7 @@ yarn storybook
 ```
 
 ## Local Testing
+
 ```
 cd ethereum-react-components
 yarn link
@@ -32,6 +36,7 @@ yarn link "ethereum-react-components"
 ```
 
 # Installation
+
 Our CI automatically bundles and publishes the latest production version to [NPM](https://www.npmjs.com/package/ethereum-react-components) and
 [GitHub Releases](https://github.com/PhilippLgh/ethereum-react-components/releases)
 
@@ -40,12 +45,13 @@ yarn add ethereum-react-components
 ```
 
 # Use in project
+
 ```
 import { Identicon } from 'ethereum-react-components';
 
 <div>
-  <Identicon seed="0xF5A5d5c30BfAC14bf207b6396861aA471F9A711D" />
+  <Identicon address="0xF5A5d5c30BfAC14bf207b6396861aA471F9A711D" />
 </div>
 ```
-For a detailed documentation check out e.g. the [Identicon story](https://philipplgh.github.io/ethereum-react-components?selectedKind=Widgets%2FIdenticon)
 
+For a detailed documentation check out e.g. the [Identicon story](https://philipplgh.github.io/ethereum-react-components?selectedKind=Widgets%2FIdenticon)

--- a/src/components/Identicon.jsx
+++ b/src/components/Identicon.jsx
@@ -18,7 +18,6 @@ export default class Identicon extends Component {
   }
 
   static defaultProps = {
-    address: '0x0000000000000000000000000000000000000000',
     size: 'medium'
   }
 
@@ -38,6 +37,10 @@ export default class Identicon extends Component {
   render() {
     const { address, size, classes } = this.props
 
+    if (!address) {
+      return <StyledSpanEmpty size={size} />
+    }
+
     return (
       <StyledSpan
         className={classes}
@@ -49,50 +52,55 @@ export default class Identicon extends Component {
     )
   }
 }
+const config = {
+  tiny: {
+    size: '21px',
+    boxShadow:
+      'inset 0 1px 1px hsla(0,0%,100%,.4), inset 0 -1px 2px rgba(0,0,0,.3)'
+  },
+  small: {
+    size: '32px',
+    boxShadow:
+      'inset 0 2px 2px hsla(0,0%,100%,.4), inset 0 -2px 4px rgba(0,0,0,.4)'
+  },
+  medium: {
+    size: '48px',
+    boxShadow:
+      'inset 0 4px 4px hsla(0,0%,100%,.4), inset 0 -4px 6px rgba(0,0,0,.5)'
+  },
+  large: {
+    size: '64px',
+    boxShadow:
+      'inset 0 4px 8px hsla(0,0%,100%,.4), inset 0 -4px 12px rgba(0,0,0,.6)'
+  }
+}
+
+const StyledSpanEmpty = styled.span`
+  background-color: white;
+  background-size: cover;
+  border-radius: 50%;
+  box-shadow: ${props => config[props.size].boxShadow};
+  display: inline-block;
+  height: ${props => config[props.size].size};
+  width: ${props => config[props.size].size};
+`
 
 const StyledSpan = styled.span`
   background-image: ${props => props.backgroundImage};
   background-size: cover;
   border-radius: 50%;
-  box-shadow: inset 0 4px 4px hsla(0,0%,100%,.4), inset 0 -4px 6px rgba(0,0,0,.5);
+  box-shadow: ${props => config[props.size].boxShadow};
   cursor: help;
   display: inline-block;
   overflow: hidden;
   transition: border-radius 2.5s;
   transition-delay: 3s;
-  height: 48px;
-  width: 48px;
+  height: ${props => config[props.size].size};
+  width: ${props => config[props.size].size};
   :hover {
     border-radius: 15%;
     transition-delay: 1s;
   }
-
-  ${props =>
-    props.size === 'tiny' &&
-    css`
-      height: 21px;
-      width: 21px;
-      box-shadow: inset 0 1px 1px hsla(0, 0%, 100%, 0.4),
-        inset 0 -1px 2px rgba(0, 0, 0, 0.3);
-    `}
-
-  ${props =>
-    props.size === 'small' &&
-    css`
-      height: 32px;
-      width: 32px;
-      box-shadow: inset 0 2px 2px hsla(0, 0%, 100%, 0.4),
-        inset 0 -2px 4px rgba(0, 0, 0, 0.4);
-    `}
-
-  ${props =>
-    props.size === 'large' &&
-    css`
-      height: 64px;
-      width: 64px;
-      box-shadow: inset 0 4px 8px hsla(0, 0%, 100%, 0.4),
-        inset 0 -4px 12px rgba(0, 0, 0, 0.6);
-    `}
 `
 
 const StyledImg = styled.img`

--- a/src/components/Identicon.jsx
+++ b/src/components/Identicon.jsx
@@ -2,96 +2,51 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import blockies from 'ethereum-blockies'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
+import i18n from '../i18n/'
 import hqxConstructor from '../lib/hqx'
 
-const mod = {
-  Math: window.Math
-}
+const mod = { Math: window.Math }
 hqxConstructor(mod)
 const { hqx } = mod
 
 export default class Identicon extends Component {
   static propTypes = {
-    seed: PropTypes.string,
+    address: PropTypes.string,
+    classes: PropTypes.string,
     size: PropTypes.oneOf(['tiny', 'small', 'medium', 'large'])
   }
 
+  static defaultProps = {
+    address: '0x0000000000000000000000000000000000000000',
+    size: 'medium'
+  }
+
   // uses hqx pixel scaling with max value 4 x 2 = factor 8
-  identiconData(identity) {
+  identiconData(address) {
     return hqx(
-      hqx(
-        blockies.create({
-          seed: identity,
-          size: 8,
-          scale: 1
-        }),
-        4
-      ),
+      hqx(blockies.create({ seed: address, size: 8, scale: 1 }), 4),
       4
     ).toDataURL()
   }
 
   // uses blockie's factor 8 scaling
-  identiconDataPixel(identity) {
-    return blockies
-      .create({
-        seed: identity,
-        size: 8,
-        scale: 8
-      })
-      .toDataURL()
+  identiconDataPixel(address) {
+    return blockies.create({ seed: address, size: 8, scale: 8 }).toDataURL()
   }
 
   render() {
-
-    const seed = this.props.seed ? this.props.seed : '0x0000000000000000000000000000000000000000'
-    const size = this.props.size ? this.props.size : 'medium'
-    const classes = this.props.classes ? this.props.classes : ''
-
-    seed === '0x0000000000000000000000000000000000000000'
-      ? console.warn("A seed was not passed as a prop to the Identicon")
-      : null
+    const { address, size, classes } = this.props
 
     return (
       <StyledSpan
         className={classes}
-        backgroundImage={`url('${this.identiconData(seed.toLowerCase())}')`}
+        backgroundImage={`url('${this.identiconData(address.toLowerCase())}')`}
         size={size}
-        title={this.props.title 
-          ? `This is a security icon. If there were any change to the address, the resulting icon would be a completely different one`
-          : null
-        }
-        >
-        <StyledImg
-          src={this.identiconDataPixel(seed.toLowerCase())}
-          className="identicon-pixel"
-        />
+        title={i18n.t('elements.identiconHelper')}>
+        <StyledImg src={this.identiconDataPixel(address.toLowerCase())} />
       </StyledSpan>
     )
-  }
-}
-
-const config = {
-  tiny: {
-    width: '21px',
-    boxShadow:
-      'inset 0 1px 1px hsla(0,0%,100%,.4), inset 0 -1px 2px rgba(0,0,0,.3)'
-  },
-  small: {
-    width: '32px',
-    boxShadow:
-      'inset 0 2px 2px hsla(0,0%,100%,.4), inset 0 -2px 4px rgba(0,0,0,.4)'
-  },
-  medium: {
-    width: '48px',
-    boxShadow:
-      'inset 0 4px 4px hsla(0,0%,100%,.4), inset 0 -4px 6px rgba(0,0,0,.5)'
-  },
-  large: {
-    width: '64px',
-    boxShadow:
-      'inset 0 4px 8px hsla(0,0%,100%,.4), inset 0 -4px 12px rgba(0,0,0,.6)'
   }
 }
 
@@ -99,18 +54,45 @@ const StyledSpan = styled.span`
   background-image: ${props => props.backgroundImage};
   background-size: cover;
   border-radius: 50%;
-  box-shadow: ${props => config[props.size].boxShadow};
+  box-shadow: inset 0 4px 4px hsla(0,0%,100%,.4), inset 0 -4px 6px rgba(0,0,0,.5);
   cursor: help;
   display: inline-block;
   overflow: hidden;
   transition: border-radius 2.5s;
   transition-delay: 3s;
-  height: ${props => config[props.size].width};
-  width: ${props => config[props.size].width};
+  height: 48px;
+  width: 48px;
   :hover {
     border-radius: 15%;
     transition-delay: 1s;
   }
+
+  ${props =>
+    props.size === 'tiny' &&
+    css`
+      height: 21px;
+      width: 21px;
+      box-shadow: inset 0 1px 1px hsla(0, 0%, 100%, 0.4),
+        inset 0 -1px 2px rgba(0, 0, 0, 0.3);
+    `}
+
+  ${props =>
+    props.size === 'small' &&
+    css`
+      height: 32px;
+      width: 32px;
+      box-shadow: inset 0 2px 2px hsla(0, 0%, 100%, 0.4),
+        inset 0 -2px 4px rgba(0, 0, 0, 0.4);
+    `}
+
+  ${props =>
+    props.size === 'large' &&
+    css`
+      height: 64px;
+      width: 64px;
+      box-shadow: inset 0 4px 8px hsla(0, 0%, 100%, 0.4),
+        inset 0 -4px 12px rgba(0, 0, 0, 0.6);
+    `}
 `
 
 const StyledImg = styled.img`

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -313,7 +313,7 @@ const en = {
     "checksumAlert":
       "This address looks valid, but it doesn't have some security features that will protect you against typos, so double check you have the right one. If provided, check if the security icon matches.",
     "identiconHelper":
-      "This is a security icon.  If there were any change to the address, the resulting icon would be a completely different one",
+      "This is a security icon.  If there were any change to the address, the resulting icon would be a completely different one.",
     "type": {
       "address": "Address",
       "bool": "Boolean",

--- a/src/stories/1.index.stories.jsx
+++ b/src/stories/1.index.stories.jsx
@@ -22,20 +22,29 @@ storiesOf('Welcome', module).add('to Ethereum Components', () => (
 
 storiesOf('Widgets/Identicon', module)
   .add('default', () => <Identicon />)
-  .add('tiny (with seed)', () => (
-    <Identicon seed="0xF5A5d5c30BfAC14bf207b6396861aA471F9A711D" size="tiny" />
-  ))
-  .add('small (with seed)', () => (
-    <Identicon seed="0xF5A5d5c30BfAC14bf207b6396861aA471F9A711D" size="small" />
-  ))
-  .add('medium (with seed)', () => (
+  .add('tiny (with address)', () => (
     <Identicon
-      seed="0xF5A5d5c30BfAC14bf207b6396861aA471F9A711D"
+      address="0xF5A5d5c30BfAC14bf207b6396861aA471F9A711D"
+      size="tiny"
+    />
+  ))
+  .add('small (with address)', () => (
+    <Identicon
+      address="0xF5A5d5c30BfAC14bf207b6396861aA471F9A711D"
+      size="small"
+    />
+  ))
+  .add('medium (with address)', () => (
+    <Identicon
+      address="0xF5A5d5c30BfAC14bf207b6396861aA471F9A711D"
       size="medium"
     />
   ))
-  .add('large (with seed)', () => (
-    <Identicon seed="0xF5A5d5c30BfAC14bf207b6396861aA471F9A711D" size="large" />
+  .add('large (with address)', () => (
+    <Identicon
+      address="0xF5A5d5c30BfAC14bf207b6396861aA471F9A711D"
+      size="large"
+    />
   ))
 
 storiesOf('Widgets/Animations/Spinner', module).add('default', () => (


### PR DESCRIPTION
#### What does it do?
- Cleans up the `Identicon` component syntax
- Styles applied for 'medium' size by deault
- **Breaking change** - API calls for `address` instead of `seed` now