### PR TITLE
fix: adds displayNames, other standardizations

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+#### What does it do?
+
+#### Any helpful background information?
+
+#### New dependencies? What are they used for?
+
+#### Relevant screenshots?

--- a/src/components/CreateAccount/FormCreateAccount.jsx
+++ b/src/components/CreateAccount/FormCreateAccount.jsx
@@ -14,7 +14,7 @@ let Mist = {
   }
 }
 
-class CreateAccount extends Component {
+export default class CreateAccount extends Component {
   static displayName = 'CreateAccount'
 
   static propTypes = {}
@@ -147,5 +147,3 @@ class CreateAccount extends Component {
     )
   }
 }
-
-export default CreateAccount

--- a/src/components/CreateAccount/InputPassword.jsx
+++ b/src/components/CreateAccount/InputPassword.jsx
@@ -5,7 +5,7 @@ import Checkbox from '../Widgets/Checkbox'
 import ValidatedField from '../Widgets/ValidatedField'
 import './InputPassword.scss'
 
-class InputPassword extends Component {
+export default class InputPassword extends Component {
   static displayName = 'InputPassword'
 
   static propTypes = {
@@ -60,5 +60,3 @@ class InputPassword extends Component {
     )
   }
 }
-
-export default InputPassword

--- a/src/components/EthAddress.jsx
+++ b/src/components/EthAddress.jsx
@@ -1,7 +1,9 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 
-class EthAddress extends Component {
+export default class EthAddress extends Component {
+  static displayName = 'EthAddress'
+
   static propTypes = {
     /** Ethereum public address (42 chars)  */
     address: PropTypes.string.isRequired,
@@ -32,5 +34,3 @@ class EthAddress extends Component {
     )
   }
 }
-
-export default EthAddress

--- a/src/components/Identicon.jsx
+++ b/src/components/Identicon.jsx
@@ -11,6 +11,8 @@ hqxConstructor(mod)
 const { hqx } = mod
 
 export default class Identicon extends Component {
+  static displayName = Identicon
+
   static propTypes = {
     address: PropTypes.string,
     classes: PropTypes.string,

--- a/src/components/Network/NetworkChooser.jsx
+++ b/src/components/Network/NetworkChooser.jsx
@@ -61,7 +61,9 @@ const NetworkOption = ({ innerProps, isDisabled, data }) => (
   </div>
 )
 
-class NetworkChooser extends Component {
+export default class NetworkChooser extends Component {
+  static displayName = 'NetworkChooser'
+
   state = {
     selectedOption: null
   }
@@ -85,5 +87,3 @@ class NetworkChooser extends Component {
     )
   }
 }
-
-export default NetworkChooser

--- a/src/components/Tools/EthConverterForm.jsx
+++ b/src/components/Tools/EthConverterForm.jsx
@@ -26,7 +26,13 @@ const options = [
   // { value: 'base56', label: 'Base56' }
 ]
 
-class EthConverterForm extends Component {
+export default class EthConverterForm extends Component {
+  static displayName = 'EthConverterForm'
+
+  static propTypes = {
+    type: PropTypes.oneOf(['keccak']).isRequired
+  }
+
   state = {
     selectedOption: options[0]
   }
@@ -52,9 +58,3 @@ class EthConverterForm extends Component {
     )
   }
 }
-
-EthConverterForm.propTypes = {
-  type: PropTypes.oneOf(['keccak']).isRequired
-}
-
-export default EthConverterForm

--- a/src/components/Tools/EthValidatedField.jsx
+++ b/src/components/Tools/EthValidatedField.jsx
@@ -1,8 +1,7 @@
-import React from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import util from 'ethereumjs-util'
-import { ValidatedField } from '..';
-
+import { ValidatedField } from '..'
 
 const config = {
   address: {
@@ -12,7 +11,7 @@ const config = {
   password: {
     placeholder: 'password',
     input: 'password',
-    validator: (pw) => {
+    validator: pw => {
       const ascii = /^[ -~]+$/
       if (!ascii.test(pw)) {
         throw new Error('illegal character (non-ascii)')
@@ -48,38 +47,47 @@ const config = {
   undefined: {
     validator: () => true
   }
-
 }
 
-const EthValidatedField = ({ type = 'undefined', value = '', placeholder, onChange, size=50 }) => {
-  config['undefined'].placeholder = placeholder
-  const { validator, placeholderConfig } = config[type]
-  const inputType = config[type].input || 'text'
-  return (
-    <ValidatedField
-      validator={validator}
-      type={inputType}
-      placeholder={placeholderConfig}
-      value={value}
-      onChange={onChange}
-      size={size}
-    />
-  )
+export default class EthValidatedField extends Component {
+  static displayName = 'ValidatedField'
+
+  static propTypes = {
+    type: PropTypes.oneOf([
+      'address',
+      'checksum-address',
+      'password',
+      'private-key',
+      'public-key',
+      'signature',
+      'zero-address'
+    ]).isRequired,
+    value: PropTypes.string,
+    size: PropTypes.any
+  }
+
+  static defaultProps = {
+    type: 'undefined',
+    value: '',
+    size: 50
+  }
+
+  render() {
+    const { type, value, placeholder, onChange, size } = this.props
+
+    config['undefined'].placeholder = placeholder
+    const { validator, placeholderConfig } = config[type]
+    const inputType = config[type].input || 'text'
+
+    return (
+      <ValidatedField
+        validator={validator}
+        type={inputType}
+        placeholder={placeholderConfig}
+        value={value}
+        onChange={onChange}
+        size={size}
+      />
+    )
+  }
 }
-
-EthValidatedField.displayName = 'ValidatedField'
-
-EthValidatedField.propTypes = {
-  type: PropTypes.oneOf([
-    'address',
-    'checksum-address',
-    'password',
-    'private-key',
-    'public-key',
-    'signature',
-    'zero-address'
-  ]).isRequired
-}
-
-
-export default EthValidatedField

--- a/src/components/Tx/History/TxHistoryList.jsx
+++ b/src/components/Tx/History/TxHistoryList.jsx
@@ -2,8 +2,9 @@ import React, { Component } from 'react'
 import i18n from '../../../i18n'
 import TxRow from './TxHistoryListEntry'
 
+export default class TxHistory extends Component {
+  static displayName = 'TxHistory'
 
-class TxHistory extends Component {
   renderTxList(txs) {
     const { etherPriceUSD, blockNumber } = this.props
     // FIXME hardcoded network
@@ -21,7 +22,8 @@ class TxHistory extends Component {
   }
 
   render() {
-    const { txs, etherPriceUSD } = this.props 
+    const { txs, etherPriceUSD } = this.props
+
     return (
       <div className="list-txs">
         <div className="header">
@@ -34,13 +36,13 @@ class TxHistory extends Component {
                 <span className="txs-total">
                   {i18n.t('txHistory.total', { count: txs.length })}
                 </span>
-              )
+                )
               </span>
             )}
           </h1>
         </div>
         <div className="tx-list">
-          { this.renderTxList(txs) }
+          {this.renderTxList(txs)}
           {txs.length === 0 && (
             <div className="no-txs">No transactions yet.</div>
           )}
@@ -49,5 +51,3 @@ class TxHistory extends Component {
     )
   }
 }
-
-export default TxHistory

--- a/src/components/Tx/History/TxHistoryListEntry.jsx
+++ b/src/components/Tx/History/TxHistoryListEntry.jsx
@@ -15,7 +15,9 @@ const TX = {
   SUCCESS: 1
 }
 
-class TxRow extends Component {
+export default class TxRow extends Component {
+  static displayName = 'TxRow'
+
   state = { showDetails: false }
 
   toggleDetails() {
@@ -51,7 +53,9 @@ class TxRow extends Component {
         subdomain = 'kovan.'
       }
       txHashLink = (
-        <a href={`https://${subdomain}etherscan.io/tx/${tx.hash}`} target="_blank">
+        <a
+          href={`https://${subdomain}etherscan.io/tx/${tx.hash}`}
+          target="_blank">
           {tx.hash}
         </a>
       )
@@ -89,7 +93,6 @@ class TxRow extends Component {
         </span>
       )
     } else if (tx.status === TX.SUCCESS && tx.blockNumber) {
-      
       const numberConfirmations = blockNumber - tx.blockNumber
       status = (
         <span>
@@ -97,9 +100,11 @@ class TxRow extends Component {
             {i18n.t('txHistory.statusConfirmed')}
           </span>{' '}
           <span>
-            ({i18n.t('txHistory.confirmations', {
+            (
+            {i18n.t('txHistory.confirmations', {
               count: numberConfirmations
-            })})
+            })}
+            )
           </span>
         </span>
       )
@@ -122,7 +127,8 @@ class TxRow extends Component {
         {tx.gasUsed && this.renderBold('txHistory.gasUsed', tx.gasUsed)}
         <div>
           {i18n.t('txHistory.gasPrice')}:{' '}
-          <span className="bold">{gasPriceEther} ether</span> ({gasPriceGwei}{' '} Gwei)
+          <span className="bold">{gasPriceEther} ether</span> ({gasPriceGwei}{' '}
+          Gwei)
         </div>
         {txCostEther && (
           <div>
@@ -133,8 +139,7 @@ class TxRow extends Component {
         )}
         {tx.data && (
           <div>
-            {i18n.t('txHistory.data')}:{' '}
-            <span className="bold">{tx.data}</span>
+            {i18n.t('txHistory.data')}: <span className="bold">{tx.data}</span>
           </div>
         )}
         <div className="tx-moreDetails" onClick={() => this.toggleDetails()}>
@@ -185,7 +190,8 @@ class TxRow extends Component {
           <div className="tx-date">{tx.createdAt}</div>
         </div>
         <div className="tx-description">{description}</div>
-        {tx.contractAddress && this.renderAddress('txHistory.newContract', tx.contractAddress)}
+        {tx.contractAddress &&
+          this.renderAddress('txHistory.newContract', tx.contractAddress)}
         {this.renderAddress('txHistory.from', tx.from)}
         {isTokenTransfer && this.renderAddress('txHistory.to', tokensTo)}
         {!isTokenTransfer && (
@@ -205,5 +211,3 @@ class TxRow extends Component {
     )
   }
 }
-
-export default TxRow

--- a/src/components/Tx/SendTx/FeeSelector.jsx
+++ b/src/components/Tx/SendTx/FeeSelector.jsx
@@ -6,13 +6,16 @@ import { Spinner } from '../../Widgets/LoadingAnimations'
 import * as util from '../../../lib/util'
 
 const BN = ethUtils.BN
-class FeeSelector extends Component {
-  propTypes = {
+
+export default class FeeSelector extends Component {
+  static displayName = 'FeeSelector'
+
+  static propTypes = {
     togglePriority: PropTypes.string.isRequired,
     gasLoading: PropTypes.bool
   }
 
-  defaultProps = {
+  static defaultProps = {
     network: 'main'
   }
 
@@ -82,7 +85,9 @@ class FeeSelector extends Component {
 
     return (
       <React.Fragment>
-        {gasLoading && <Spinner singleColor="#00aafa" size={16} className="react-spinner" /> }
+        {gasLoading && (
+          <Spinner singleColor="#00aafa" size={16} className="react-spinner" />
+        )}
         {error}
       </React.Fragment>
     )
@@ -91,31 +96,24 @@ class FeeSelector extends Component {
   render() {
     return (
       <div className="fee-selector">
-        {this.props.priority 
-        ? (
+        {this.props.priority ? (
           <span
             onClick={this.handleClick}
             className="fee-selector__btn"
-            data-tooltip="Click For Standard Fee"
-          >
+            data-tooltip="Click For Standard Fee">
             {i18n.t('mist.sendTx.priorityFee')}
           </span>
-        ) 
-        : (
+        ) : (
           <span
             onClick={this.handleClick}
             className="fee-selector__btn"
-            data-tooltip="Click For Priority Fee"
-          >
+            data-tooltip="Click For Priority Fee">
             {i18n.t('mist.sendTx.standardFee')}
           </span>
-        )}
-        {' '}
+        )}{' '}
         <span className="fee-amount">{this.parseFee()}</span>
         {this.renderStatus()}
       </div>
     )
   }
 }
-
-export default FeeSelector

--- a/src/components/Tx/SendTx/FormSendTx.jsx
+++ b/src/components/Tx/SendTx/FormSendTx.jsx
@@ -5,8 +5,9 @@ import FormSubmit from './FormSubmitTx'
 import GasNotification from './GasNotification'
 import TxParties from './TxParties'
 
+export default class SendTx extends Component {
+  static displayName = 'SendTx'
 
-class SendTx extends Component {
   state = {
     hasSignature: false,
     providedGas: 0,
@@ -24,11 +25,9 @@ class SendTx extends Component {
     return 0
   }
 
-  togglePriority = () => {
+  togglePriority = () => {}
 
-  }
-
-  handleSubmit = (formData) => {
+  handleSubmit = formData => {
     const {
       data,
       to,
@@ -41,7 +40,8 @@ class SendTx extends Component {
     } = this.props.newTx
 
     // If no gas value was provided, use estimatedGas
-    const gasValue = parseInt(gas, 16) !== 0 ? gas : `0x${estimatedGas.toString(16)}`
+    const gasValue =
+      parseInt(gas, 16) !== 0 ? gas : `0x${estimatedGas.toString(16)}`
 
     // If priority tx, double the value and format it
     const chosenPrice = priority ? '0x' + (gasPrice * 2).toString(16) : gasPrice
@@ -152,11 +152,8 @@ class SendTx extends Component {
               handleSubmit={this.handleSubmit}
             />
           </div>
-
         </div>
       </div>
     )
   }
 }
-
-export default SendTx

--- a/src/components/Tx/SendTx/FormSubmitTx.jsx
+++ b/src/components/Tx/SendTx/FormSubmitTx.jsx
@@ -4,7 +4,9 @@ import styled, { css } from 'styled-components'
 import { Button } from '../../'
 import i18n from '../../../i18n'
 
-class FormSubmitTx extends Component {
+export default class FormSubmitTx extends Component {
+  static displayName = 'FormSubmitTx'
+
   static propTypes = {
     handleSubmit: PropTypes.func.isRequired,
     unlocking: PropTypes.bool,
@@ -50,8 +52,6 @@ class FormSubmitTx extends Component {
     )
   }
 }
-
-export default FormSubmitTx
 
 const StyledForm = styled.form`
   display: flex;

--- a/src/components/Tx/SendTx/TxDescription.jsx
+++ b/src/components/Tx/SendTx/TxDescription.jsx
@@ -3,9 +3,7 @@ import PropTypes from 'prop-types'
 import i18n from '../../../i18n'
 import * as util from '../../../lib/util'
 
-
-class TxDescription extends Component {
-
+export default class TxDescription extends Component {
   static displayName = 'TxDescription'
 
   static propTypes = {
@@ -29,10 +27,13 @@ class TxDescription extends Component {
     showDetails: false
   }
 
-
   formattedBalance() {
     const { value } = this.props
-    return util.formatBalance(util.toBN(value || 0), '0,0.00[0000000000000000]', 'ether')
+    return util.formatBalance(
+      util.toBN(value || 0),
+      '0,0.00[0000000000000000]',
+      'ether'
+    )
   }
 
   calculateTransferValue() {
@@ -52,7 +53,7 @@ class TxDescription extends Component {
   }
 
   handleDetailsClick = () => {
-    const {adjustWindowHeight} = this.props
+    const { adjustWindowHeight } = this.props
     const { showDetails } = this.props
     this.setState({ showDetails: !showDetails }, adjustWindowHeight)
   }
@@ -90,7 +91,7 @@ class TxDescription extends Component {
     const { params, token } = this.props
     if (params.length === 0) return <div />
 
-    const tokenCount = params[1].value.slice(0,-Math.abs(token.decimals))
+    const tokenCount = params[1].value.slice(0, -Math.abs(token.decimals))
 
     const tokenSymbol = token.symbol || i18n.t('mist.sendTx.tokens')
 
@@ -163,7 +164,7 @@ class TxDescription extends Component {
       isNewContract,
       toIsContract,
       token,
-      value,
+      value
     } = this.props
 
     if (!toIsContract && !isNewContract) {
@@ -188,8 +189,7 @@ class TxDescription extends Component {
       return (
         <div
           className="execution-context__details-link"
-          onClick={this.handleDetailsClick}
-        >
+          onClick={this.handleDetailsClick}>
           {i18n.t('mist.sendTx.showDetails')}
         </div>
       )
@@ -295,8 +295,7 @@ class TxDescription extends Component {
 
         <div
           className="execution-context__details-link"
-          onClick={this.handleDetailsClick}
-        >
+          onClick={this.handleDetailsClick}>
           {i18n.t('mist.sendTx.hideDetails')}
         </div>
       </div>
@@ -321,5 +320,3 @@ class TxDescription extends Component {
     )
   }
 }
-
-export default TxDescription

--- a/src/components/Tx/SendTx/TxParties.jsx
+++ b/src/components/Tx/SendTx/TxParties.jsx
@@ -3,8 +3,9 @@ import Identicon from '../../Identicon'
 import i18n from '../../../i18n'
 import * as util from '../../../lib/util'
 
+export default class TxParties extends Component {
+  static displayName = 'TxParties'
 
-class TxParties extends Component {
   totalAmount = () => {
     var amount = EthTools.formatBalance(
       web3.utils.toBN(this.props.value || 0),
@@ -38,12 +39,11 @@ class TxParties extends Component {
           className={
             'tx-parties__direction-name ' +
             (toIsContract &&
-              !isNewContract &&
-              executionFunction !== 'transfer(address,uint256)'
+            !isNewContract &&
+            executionFunction !== 'transfer(address,uint256)'
               ? 'is-contract'
               : '')
-          }
-        >
+          }>
           {i18n.t('mist.sendTx.from')}
         </div>
         <div>
@@ -88,8 +88,7 @@ class TxParties extends Component {
             className={
               'tx-parties__direction-name ' +
               (toIsContract ? 'is-contract' : '')
-            }
-          >
+            }>
             {toIsContract
               ? i18n.t('mist.sendTx.contract')
               : i18n.t('mist.sendTx.to')}
@@ -113,8 +112,7 @@ class TxParties extends Component {
             <div
               className={`function-signature ${
                 hasSignature ? 'has-signature' : ''
-                }`}
-            >
+              }`}>
               {executionFunction}
             </div>
           )}
@@ -132,5 +130,3 @@ class TxParties extends Component {
     )
   }
 }
-
-export default TxParties

--- a/src/components/Widgets/AnimatedIcons/AnimatedCross.jsx
+++ b/src/components/Widgets/AnimatedIcons/AnimatedCross.jsx
@@ -1,33 +1,44 @@
 // https://codepen.io/vissuel/pen/WwmOdO
 
-import React from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import './AnimatedCross.scss'
 
-const Cross = ({ size }) => (
-  <svg
-    className="cross__svg"
-    xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 52 52"
-    style={{
-      width: size,
-      height: size
-    }}
-  >
-    <circle className="cross__circle" cx="26" cy="26" r="25" fill="none" />
-    <path className="cross__path cross__path--right" fill="none" d="M16,16 l20,20" />
-    <path className="cross__path cross__path--right" fill="none" d="M16,36 l20,-20" />
-  </svg>
-)
+export default class Cross extends Component {
+  static displayName = 'AnimatedCross'
 
-Cross.displayName = 'AnimatedCross';
+  static propTypes = {
+    size: PropTypes.number
+  }
 
-Cross.propTypes = {
-  size: PropTypes.number,
-};
+  static defaultProps = {
+    size: 32
+  }
 
-Cross.defaultProps = {
-  size: 32,
-};
+  render() {
+    const { size } = this.props
 
-export default Cross
+    return (
+      <svg
+        className="cross__svg"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 52 52"
+        style={{
+          width: size,
+          height: size
+        }}>
+        <circle className="cross__circle" cx="26" cy="26" r="25" fill="none" />
+        <path
+          className="cross__path cross__path--right"
+          fill="none"
+          d="M16,16 l20,20"
+        />
+        <path
+          className="cross__path cross__path--right"
+          fill="none"
+          d="M16,36 l20,-20"
+        />
+      </svg>
+    )
+  }
+}

--- a/src/components/Widgets/AnimatedIcons/Checkmark.jsx
+++ b/src/components/Widgets/AnimatedIcons/Checkmark.jsx
@@ -1,38 +1,44 @@
 // https://codepen.io/haniotis/pen/KwvYLO
 
-import React from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import './Checkmark.scss'
 
-const Checkmark = ({ size }) => (
-  <svg
-    className="checkmark"
-    style={{
-      width: size,
-      height: size
-    }}
-    xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 52 52"
-  >
-    <circle
-      className="checkmark__circle"
-      cx="26"
-      cy="26"
-      r="25"
-      fill="none"
-    />
-    <path className="checkmark__check" fill="none" d="M14.1 27.2l7.1 7.2 16.7-16.8" />
-  </svg>
-)
+export default class Checkmark extends Component {
+  static displayName = 'Checkmark'
 
-Checkmark.displayName = 'Checkmark';
+  static propTypes = {
+    size: PropTypes.number
+  }
 
-Checkmark.propTypes = {
-  size: PropTypes.number,
-};
+  static defaultProps = {
+    size: 32
+  }
 
-Checkmark.defaultProps = {
-  size: 32,
-};
-
-export default Checkmark
+  render() {
+    const { size } = this.props
+    return (
+      <svg
+        className="checkmark"
+        style={{
+          width: size,
+          height: size
+        }}
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 52 52">
+        <circle
+          className="checkmark__circle"
+          cx="26"
+          cy="26"
+          r="25"
+          fill="none"
+        />
+        <path
+          className="checkmark__check"
+          fill="none"
+          d="M14.1 27.2l7.1 7.2 16.7-16.8"
+        />
+      </svg>
+    )
+  }
+}

--- a/src/components/Widgets/Button.jsx
+++ b/src/components/Widgets/Button.jsx
@@ -2,10 +2,13 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
 
-class Button extends Component {
+export default class Button extends Component {
+  static displayName = 'Button'
+
   static propTypes = {
     children: PropTypes.node,
     disabled: PropTypes.bool,
+    error: PropTypes.bool,
     flat: PropTypes.bool,
     loading: PropTypes.bool,
     onClick: PropTypes.func,
@@ -79,5 +82,3 @@ const StyledButton = styled.button`
       background-color: #f66d6f;
     `}
 `
-
-export default Button

--- a/src/components/Widgets/Checkbox.jsx
+++ b/src/components/Widgets/Checkbox.jsx
@@ -2,7 +2,9 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
-class Checkbox extends Component {
+export default class Checkbox extends Component {
+  static displayName = 'Checkbox'
+
   static propTypes = {
     id: PropTypes.string.isRequired,
     name: PropTypes.string,
@@ -85,5 +87,3 @@ const StyledCheckboxLabel = styled.label`
   font-size: 14px;
   font-weight: 300;
 `
-
-export default Checkbox

--- a/src/components/Widgets/ConverterForm.jsx
+++ b/src/components/Widgets/ConverterForm.jsx
@@ -2,7 +2,9 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { ValidatedField } from '..'
 
-class ConverterForm extends Component {
+export default class ConverterForm extends Component {
+  static displayName = 'ConverterForm'
+
   static propTypes = {}
 
   static defaultProps = {}
@@ -48,5 +50,3 @@ class ConverterForm extends Component {
     )
   }
 }
-
-export default ConverterForm

--- a/src/components/Widgets/LoadingAnimations.jsx
+++ b/src/components/Widgets/LoadingAnimations.jsx
@@ -1,88 +1,110 @@
-import React from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import 'loaders.css'
 import './LoadingAnimations.css'
 
 // for more examples see https://connoratherton.com/loaders
 // https://github.com/ConnorAtherton/loaders.css
-export const Spinner = ({ pstyle }) => {
-  const divCount = 8
-  const style = {
-    backgroundColor: '#AAA'
+export class Spinner extends Component {
+  static displayName = 'Spinner'
+
+  static propTypes = {
+    pstyle: PropTypes.any
   }
-  return (
-    <div
-      className="loader"
-      style={{
-        ...pstyle,
-        width: '65px',
-        height: '65px',
-      }}
-    >
-      <div className="ball-spin-fade-loader">
-        {
-          [...Array(divCount)].map((_, idx) => <div key={idx} style={style} />)
-        }
+
+  render() {
+    const { pstyle } = this.props
+
+    const divCount = 8
+    const style = { backgroundColor: '#AAA' }
+
+    return (
+      <div
+        className="loader"
+        style={{
+          ...pstyle,
+          width: '65px',
+          height: '65px'
+        }}>
+        <div className="ball-spin-fade-loader">
+          {[...Array(divCount)].map((_, idx) => (
+            <div key={idx} style={style} />
+          ))}
+        </div>
       </div>
-    </div>
-  )
+    )
+  }
 }
 
-Spinner.displayName = 'Spinner'
+export class Pulse extends Component {
+  static displayName = 'Pulse'
 
-export const Pulse = ({ pstyle, multiple = false, fill = false, color = '#CCC' }) => {
+  static propTypes = {
+    pstyle: PropTypes.any,
+    multiple: PropTypes.bool,
+    fill: PropTypes.bool,
+    color: PropTypes.string
+  }
 
-  let type = multiple === true ? 'multiple' : 'one'
-  type += fill === true ? '-filled' : ''
+  static defaultProps = {
+    multiple: false,
+    fill: false,
+    color: '#CCC'
+  }
 
-  const config = {
-    one: {
-      class: 'ball-scale-ripple',
-      divs: 1,
-      style: {
-        borderColor: color
-      }
-    },
-    'one-filled': {
-      class: 'ball-scale',
-      divs: 1,
-      style: {
-        backgroundColor: color
-      }
-    },
-    multiple: {
-      class: 'ball-scale-ripple-multiple',
-      divs: 3,
-      style: {
-        borderColor: color
-      }
-    },
-    'multiple-filled': {
-      class: 'ball-scale-multiple',
-      divs: 3,
-      style: {
-        backgroundColor: color
+  render() {
+    const { pstyle, multiple, fill, color } = this.props
+
+    let type = multiple === true ? 'multiple' : 'one'
+    type += fill === true ? '-filled' : ''
+
+    const config = {
+      one: {
+        class: 'ball-scale-ripple',
+        divs: 1,
+        style: {
+          borderColor: color
+        }
+      },
+      'one-filled': {
+        class: 'ball-scale',
+        divs: 1,
+        style: {
+          backgroundColor: color
+        }
+      },
+      multiple: {
+        class: 'ball-scale-ripple-multiple',
+        divs: 3,
+        style: {
+          borderColor: color
+        }
+      },
+      'multiple-filled': {
+        class: 'ball-scale-multiple',
+        divs: 3,
+        style: {
+          backgroundColor: color
+        }
       }
     }
-  }
 
-  type = config[type]
+    type = config[type]
 
-  return (
-    <div
-      className="loader"
-      style={{
-        ...pstyle,
-        width: '65px',
-        height: '65px',
-      }}
-    >
-      <div className={type.class}>
-        {
-          [...Array(type.divs)].map((_, idx) => <div key={idx} style={type.style} />)
-        }
+    return (
+      <div
+        className="loader"
+        style={{
+          ...pstyle,
+          width: '65px',
+          height: '65px'
+        }}>
+        <div className={type.class}>
+          {[...Array(type.divs)].map((_, idx) => (
+            <div key={idx} style={type.style} />
+          ))}
+        </div>
       </div>
-    </div>
-  )
+    )
+  }
 }
-
-Pulse.displayName = 'Pulse'

--- a/src/components/Widgets/ValidatedField.jsx
+++ b/src/components/Widgets/ValidatedField.jsx
@@ -6,7 +6,9 @@ import Cross from './AnimatedIcons/AnimatedCross'
 
 const height = 50
 
-class ValidatedField extends Component {
+export default class ValidatedField extends Component {
+  static displayName = 'ValidatedField'
+
   static propTypes = {
     onChange: PropTypes.func,
     placeholder: PropTypes.string,
@@ -128,5 +130,3 @@ const StyledInput = styled.input`
     border-color: #4a90e2;
   }
 `
-
-export default ValidatedField

--- a/src/stories/1.index.stories.jsx
+++ b/src/stories/1.index.stories.jsx
@@ -62,7 +62,7 @@ storiesOf('Widgets/Animations/Icons', module)
   .add('checkmark', () => <Checkmark />)
   .add('cross', () => <Cross />)
 
-storiesOf('Widgets/Buttons/Button', module)
+storiesOf('Widgets/Button', module)
   .add('default', () => <Button>click me</Button>)
   .add('disabled', () => <Button disabled>click me</Button>)
   .add('secondary', () => <Button secondary>click me</Button>)


### PR DESCRIPTION
#### What does it do?
- Adds `displayName`s for everything
- Standardizes export statements
- Refactors some of the remaining funcs to follow the component patterns
- Adds a PR template
- I think this finally: closes #33, closes #32, closes #31 
#### Background
- Skips over Network components as to avoid  conflicts with @ryanio's work
- A draft of the [style checklist](https://gist.github.com/marcgarreau/a27e0d6d24305f4b79170df97a10e88b)