### PR TITLE
chore: update deploy script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -11,7 +11,7 @@ export FILES_CHANGED=`git status ./docs --untracked-files=no --porcelain | wc -l
 if [[ $FILES_CHANGED -gt 0 ]]; then
   git add docs;
   git commit -am 'Updating github pages [ci skip]';
-  git push origin $BRANCH;
+  # will be git-pushed within `standard-version` command.
 fi
 
 


### PR DESCRIPTION
#### What does it do?

Currently, the deploy process creates two commits with separate `git push`. This PR removes one of those, so CircleCI does not get flooded with skipped tasks.

<img width="698" alt="image" src="https://user-images.githubusercontent.com/47108/49750647-a052b600-fc92-11e8-82e0-0b473d5c6327.png">
